### PR TITLE
Fix for Symfony namespace issue with Datetime.

### DIFF
--- a/lib/ObjectSerializer.php
+++ b/lib/ObjectSerializer.php
@@ -250,7 +250,7 @@ class ObjectSerializer
         } elseif ($class === 'object') {
             settype($data, 'array');
             return $data;
-        } elseif ($class === '\DateTime') {
+        } elseif ( $class === '\DateTime' || $class === '\GoDaddyDomainsClient\Model\Datetime' ) {
             // Some API's return an invalid, empty string as a
             // date-time property. DateTime::__construct() will return
             // the current time for empty input which is probably not


### PR DESCRIPTION
PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\ClassNotFoundException: Attempted to load class "Datetime" from namespace "\GoDaddyDomainsClient\Model".
Did you forget a "use" statement for another namespace? in /vendor/gellu/godaddy-api-client/lib/ObjectSerializer.php:163